### PR TITLE
Parameterize the type of the draggable element's `key`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ import Draggable
 #### 2. Define your model
 Include:
 - The element's position.
-- The internal `Drag` state. Note that, for simplicity, the model entry holding this state **must** be called `drag`, since the update function below follows this naming convention. A future update could allow using custom field names.
+- The internal `Drag` state. Note that, for simplicity, the model entry holding this state **must** be called `drag`, since the update function below follows this naming convention. A future update could allow using custom field names. Please note that for the sake of example, we are specifying `String` as the type to tag draggable elements with. If you have only one such element, `()` might be a better type.
 ```elm
 type alias Model =
     { position : ( Int, Int )
-    , drag : Draggable.State
+    , drag : Draggable.State String
     }
 ```
 
@@ -57,13 +57,13 @@ initModel =
 ```elm
 type Msg
     = OnDragBy Draggable.Delta
-    | DragMsg Draggable.Msg
+    | DragMsg (Draggable.Msg String)
 ```
 
 #### 5. Setup the config used when updating the `Drag` state
 For the simplest case, you only have to provide a handler for `onDragBy`:
 ```elm
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config String Msg
 dragConfig =
     Draggable.basicConfig OnDragBy
 ```
@@ -94,7 +94,7 @@ subscriptions { drag } =
 ```
 
 #### 8. Triggering drag
-Finally, inside your `view` function, you must somehow make the element draggable. You do that by adding a trigger for the `mousedown` event. You must also specify a `String` `key` for that element. This is useful when there are multiple drag targets in the same view.
+Finally, inside your `view` function, you must somehow make the element draggable. You do that by adding a trigger for the `mousedown` event. You must also specify a `key` for that element. This can be useful when there are multiple drag targets in the same view.
 
 Of course, you'll also have to style your DOM element such that it reflects its moving position (with `top: x; left: y` or [`transform: translate`](http://www.w3schools.com/css/css3_2dtransforms.asp))
 ```elm
@@ -128,7 +128,7 @@ All of these events are optional, and can be provided to `Draggable.customConfig
 import Draggable
 import Draggable.Events exposing (onClick, onDragBy, onDragEnd, onDragStart, onMouseDown)
 
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config String Msg
 dragConfig =
     Draggable.customConfig
         [ onDragStart OnDragStart

--- a/examples/BasicExample.elm
+++ b/examples/BasicExample.elm
@@ -13,13 +13,13 @@ type alias Position =
 
 type alias Model =
     { xy : Position
-    , drag : Draggable.State
+    , drag : Draggable.State ()
     }
 
 
 type Msg
     = OnDragBy Draggable.Delta
-    | DragMsg Draggable.Msg
+    | DragMsg (Draggable.Msg ())
 
 
 main : Program Never Model Msg
@@ -39,7 +39,7 @@ init =
     )
 
 
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config () Msg
 dragConfig =
     Draggable.basicConfig OnDragBy
 
@@ -77,7 +77,7 @@ view { xy } =
     in
         Html.div
             [ A.style style
-            , Draggable.mouseTrigger "" DragMsg
+            , Draggable.mouseTrigger () DragMsg
             ]
             [ Html.text "Drag me" ]
 

--- a/examples/ConstraintsExample.elm
+++ b/examples/ConstraintsExample.elm
@@ -27,7 +27,7 @@ type alias Position =
 
 type alias Model =
     { position : Position
-    , drag : Draggable.State
+    , drag : Draggable.State String
     , dragHorizontally : Bool
     , dragVertically : Bool
     , isDragging : Bool
@@ -36,7 +36,7 @@ type alias Model =
 
 type Msg
     = NoOp
-    | DragMsg Draggable.Msg
+    | DragMsg (Draggable.Msg String)
     | OnDragBy Draggable.Delta
     | SetDragHorizontally Bool
     | SetDragVertically Bool
@@ -55,7 +55,7 @@ init =
     )
 
 
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config String Msg
 dragConfig =
     Draggable.customConfig
         [ onDragBy (OnDragBy)

--- a/examples/CustomEventsExample.elm
+++ b/examples/CustomEventsExample.elm
@@ -18,7 +18,7 @@ type alias Model =
     , clicksCount : Int
     , isDragging : Bool
     , isClicked : Bool
-    , drag : Draggable.State
+    , drag : Draggable.State String
     }
 
 
@@ -28,7 +28,7 @@ type Msg
     | OnDragEnd
     | CountClick
     | SetClicked Bool
-    | DragMsg Draggable.Msg
+    | DragMsg (Draggable.Msg String)
 
 
 main : Program Never Model Msg
@@ -53,7 +53,7 @@ init =
     )
 
 
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config String Msg
 dragConfig =
     Draggable.customConfig
         [ onDragStart (\_ -> OnDragStart)

--- a/examples/MultipleTargetsExample.elm
+++ b/examples/MultipleTargetsExample.elm
@@ -120,12 +120,12 @@ toggleBoxClicked id group =
 
 type alias Model =
     { boxGroup : BoxGroup
-    , drag : Draggable.State
+    , drag : Draggable.State Id
     }
 
 
 type Msg
-    = DragMsg Draggable.Msg
+    = DragMsg (Draggable.Msg Id)
     | OnDragBy Vec2
     | StartDragging String
     | ToggleBoxClicked String
@@ -150,7 +150,7 @@ init =
     )
 
 
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config Id Msg
 dragConfig =
     Draggable.customConfig
         [ onDragBy (Vector2.fromTuple >> OnDragBy)

--- a/examples/PanAndZoomExample.elm
+++ b/examples/PanAndZoomExample.elm
@@ -30,12 +30,12 @@ type alias Model =
     { zoom : Float
     , center : Vec2
     , size : Size Float
-    , drag : Draggable.State
+    , drag : Draggable.State ()
     }
 
 
 type Msg
-    = DragMsg Draggable.Msg
+    = DragMsg (Draggable.Msg ())
     | OnDragBy Vec2
     | Zoom Float
 
@@ -51,7 +51,7 @@ init =
     )
 
 
-dragConfig : Draggable.Config Msg
+dragConfig : Draggable.Config () Msg
 dragConfig =
     Draggable.basicConfig (OnDragBy << Vector2.fromTuple)
 
@@ -107,7 +107,7 @@ view { center, size, zoom } =
             [ num Attr.width size.width
             , num Attr.height size.height
             , handleZoom Zoom
-            , Draggable.mouseTrigger "" DragMsg
+            , Draggable.mouseTrigger () DragMsg
             ]
             [ background
             , Svg.g

--- a/src/Draggable/Events.elm
+++ b/src/Draggable/Events.elm
@@ -5,35 +5,27 @@ module Draggable.Events
         , onDragEnd
         , onClick
         , onMouseDown
-        , Key
         )
 
 {-| Listeners for the various events involved in dragging (`onDragBy`, `onDragStart`, etc.). Also handles `click` events when the mouse was not moved.
 @docs onDragStart, onDragEnd, onDragBy
 @docs onClick, onMouseDown
-@docs Key
 -}
 
 import Internal exposing (Config, Delta)
 import Draggable exposing (Event)
 
 
-{-| Type representing a key used for targeting draggable elements.
--}
-type alias Key =
-    String
-
-
 {-| Register a `DragStart` event listener. It will not trigger if the mouse has not moved while it was pressed. It receives the element key.
 -}
-onDragStart : (Key -> msg) -> Event msg
+onDragStart : (a -> msg) -> Event a msg
 onDragStart toMsg config =
     { config | onDragStart = Just << toMsg }
 
 
 {-| Register a `DragEnd` event listener. It will not trigger if the mouse has not moved while it was pressed.
 -}
-onDragEnd : msg -> Event msg
+onDragEnd : msg -> Event a msg
 onDragEnd toMsg config =
     { config | onDragEnd = Just toMsg }
 
@@ -44,20 +36,20 @@ onDragEnd toMsg config =
         OnDragBy (dx, dy) ->
             { model | position = { x = position.x + dx, y = position.y + dy } }
 -}
-onDragBy : (Delta -> msg) -> Event msg
+onDragBy : (Delta -> msg) -> Event a msg
 onDragBy toMsg config =
     { config | onDragBy = Just << toMsg }
 
 
 {-| Register a `Click` event listener. It will trigger if the mouse is pressed and immediately release, without any move. It receives the element key.
 -}
-onClick : (Key -> msg) -> Event msg
+onClick : (a -> msg) -> Event a msg
 onClick toMsg config =
     { config | onClick = Just << toMsg }
 
 
-{-| Register a `MouseDown` event listener. It will trigger whenever the mouse is pressed and will indicate the target element by the given `String` key.
+{-| Register a `MouseDown` event listener. It will trigger whenever the mouse is pressed and will indicate the target element by the given key.
 -}
-onMouseDown : (Key -> msg) -> Event msg
+onMouseDown : (a -> msg) -> Event a msg
 onMouseDown toMsg config =
     { config | onMouseDown = Just << toMsg }

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -3,18 +3,14 @@ module Internal exposing (..)
 import Mouse exposing (Position)
 
 
-type alias Key =
-    String
-
-
-type State
+type State a
     = NotDragging
-    | DraggingTentative Key Position
+    | DraggingTentative a Position
     | Dragging Position
 
 
-type Msg
-    = StartDragging Key Position
+type Msg a
+    = StartDragging a Position
     | DragAt Position
     | StopDragging
 
@@ -23,20 +19,20 @@ type alias Delta =
     ( Float, Float )
 
 
-type alias Config msg =
-    { onDragStart : Key -> Maybe msg
+type alias Config a msg =
+    { onDragStart : a -> Maybe msg
     , onDragBy : Delta -> Maybe msg
     , onDragEnd : Maybe msg
-    , onClick : Key -> Maybe msg
-    , onMouseDown : Key -> Maybe msg
+    , onClick : a -> Maybe msg
+    , onMouseDown : a -> Maybe msg
     }
 
 
-type alias Event msg =
-    Config msg -> Config msg
+type alias Event a msg =
+    Config a msg -> Config a msg
 
 
-defaultConfig : Config msg
+defaultConfig : Config a msg
 defaultConfig =
     { onDragStart = \_ -> Nothing
     , onDragBy = \_ -> Nothing
@@ -46,7 +42,7 @@ defaultConfig =
     }
 
 
-updateAndEmit : Config msg -> Msg -> State -> ( State, Maybe msg )
+updateAndEmit : Config a msg -> Msg a -> State a -> ( State a, Maybe msg )
 updateAndEmit config msg drag =
     case ( drag, msg ) of
         ( NotDragging, StartDragging key initialPosition ) ->
@@ -88,7 +84,7 @@ distanceTo end start =
     )
 
 
-logInvalidState : State -> Msg -> a -> a
+logInvalidState : State a -> Msg a -> b -> b
 logInvalidState drag msg result =
     let
         str =

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -4,7 +4,7 @@ import Fuzz exposing (Fuzzer)
 import Mouse exposing (Position)
 import Test exposing (..)
 import Expect as Should exposing (Expectation)
-import Internal exposing (Delta, Key, Msg(..), State(..))
+import Internal exposing (Delta, Msg(..), State(..))
 
 
 all : Test
@@ -18,19 +18,24 @@ all =
         ]
 
 
-type EmitMsg
-    = OnDragStart Key
+type Key
+    = Key String
+
+
+type EmitMsg a
+    = OnDragStart a
     | OnDragBy Delta
     | OnDragEnd
-    | OnClick Key
-    | OnMouseDown Key
+    | OnClick a
+    | OnMouseDown a
 
 
+updateWithEvents : Msg a -> State a -> ( State a, Maybe (EmitMsg a) )
 updateWithEvents =
     Internal.updateAndEmit fullConfig
 
 
-fullConfig : Internal.Config EmitMsg
+fullConfig : Internal.Config a (EmitMsg a)
 fullConfig =
     { onDragStart = Just << OnDragStart
     , onDragBy = Just << OnDragBy
@@ -40,16 +45,17 @@ fullConfig =
     }
 
 
+defaultUpdate : Msg a -> State a -> ( State a, Maybe msg )
 defaultUpdate =
     Internal.updateAndEmit Internal.defaultConfig
 
 
-defaultKey : String
+defaultKey : Key
 defaultKey =
-    "defaultKey"
+    Key "defaultKey"
 
 
-startDragging : Position -> Msg
+startDragging : Position -> Msg Key
 startDragging =
     StartDragging defaultKey
 
@@ -145,7 +151,7 @@ positionF =
 
 keyF : Fuzzer Key
 keyF =
-    Fuzz.string
+    Fuzz.map Key Fuzz.string
 
 
 


### PR DESCRIPTION
I am a big fan of this library, and am currently leading a team to rebuild a legacy flash application in Elm. This took care of much of the heavy lifting.

However, I do not like that I have to `toString` all over the place to "tag" my draggable elements, and then write ugly string-munging functions to get back the original record inside `update`.

I think other users might also benefit from this increased flexibility.

P. S. As written now, this in 3.0.0; it could potentially be rewritten in such a way as to be 2.1.0, but that seems messier to support two APIs.

P. P. S. I didn't proofread my docs changes super thoroughly yet.