### PR TITLE
Freeze versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
 node_js:
   - "6.9"
 install:
-  - npm install -g elm elm-test
+  - npm install -g elm@0.18 elm-test@0.18.2
 script:
   - elm-test

--- a/src/Draggable.elm
+++ b/src/Draggable.elm
@@ -14,29 +14,40 @@ module Draggable
         , subscriptions
         )
 
-{-|
-This library provides and easy way to make DOM elements (Html or Svg) draggable.
+{-| This library provides and easy way to make DOM elements (Html or Svg) draggable.
+
 
 ## When is dragging considered?
+
 An element is considered to be dragging when the mouse is pressed **and** moved before it is released. Otherwise, the action is considered a click. This is useful because in some cases you may want to support both actions.
 
 [See examples](https://github.com/zaboco/elm-draggable/tree/master/examples)
 
 
 # Initial State
+
 @docs init
 
+
 # Config
+
 @docs basicConfig, customConfig
 
+
 # Update
+
 @docs update, subscriptions
 
+
 # DOM trigger
+
 @docs mouseTrigger, customMouseTrigger
 
+
 # Definitions
+
 @docs Delta, State, Msg, Config, Event
+
 -}
 
 import Cmd.Extra
@@ -118,6 +129,7 @@ subscriptions envelope (State drag) =
 {-| DOM event handler to start dragging on mouse down. It requires a key for the element, in order to provide support for multiple drag targets sharing the same drag state. Of course, if only one element is draggable, it can have any value, including `()`.
 
     div [ mouseTrigger "element-id" DragMsg ] [ text "Drag me" ]
+
 -}
 mouseTrigger : a -> (Msg a -> msg) -> VirtualDom.Property msg
 mouseTrigger key envelope =
@@ -129,6 +141,7 @@ mouseTrigger key envelope =
 {-| DOM event handler to start dragging on mouse down and also sending custom information about the `mousedown` event. It does so by using a custom `Decoder` for the [`MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent).
 
     div [ mouseTrigger offsetDecoder CustomDragMsg ] [ text "Drag me" ]
+
 -}
 customMouseTrigger : Decoder a -> (Msg () -> a -> msg) -> VirtualDom.Property msg
 customMouseTrigger customDecoder customEnvelope =
@@ -177,7 +190,9 @@ type Config a msg
 
 {-| Basic config
 
-    config = basicConfig OnDragBy
+    config =
+        basicConfig OnDragBy
+
 -}
 basicConfig : (Delta -> msg) -> Config a msg
 basicConfig onDragByListener =
@@ -190,11 +205,13 @@ basicConfig onDragByListener =
 
 {-| Custom config, including arbitrary options. See [`Events`](#Draggable-Events).
 
-    config = customConfig
-        [ onDragBy OnDragBy
-        , onDragStart OnDragStart
-        , onDragEnd OnDragEnd
-        ]
+    config =
+        customConfig
+            [ onDragBy OnDragBy
+            , onDragStart OnDragStart
+            , onDragEnd OnDragEnd
+            ]
+
 -}
 customConfig : List (Event a msg) -> Config a msg
 customConfig events =

--- a/src/Draggable/Events.elm
+++ b/src/Draggable/Events.elm
@@ -35,6 +35,7 @@ onDragEnd toMsg config =
     case Msg of
         OnDragBy (dx, dy) ->
             { model | position = { x = position.x + dx, y = position.y + dy } }
+
 -}
 onDragBy : (Delta -> msg) -> Event a msg
 onDragBy toMsg config =


### PR DESCRIPTION
Latest version of `elm-test` (`0.18.6`) does not work on this format, so we're using the last version that worked. Also, freezing the elm version so the build won't fail when elm@0.19 comes. 