### PR TITLE
Set PageX and PageY to be ints after truncating them as floats

### DIFF
--- a/src/Draggable.elm
+++ b/src/Draggable.elm
@@ -178,8 +178,8 @@ baseDecoder key =
 positionDecoder : Decoder Position
 positionDecoder =
     Decode.map2 Position
-        (Decode.field "pageX" Decode.int)
-        (Decode.field "pageY" Decode.int)
+        (Decode.field "pageX" Decode.float |> Decode.map truncate)
+        (Decode.field "pageY" Decode.float |> Decode.map truncate)
 
 
 alwaysPreventDefaultAndStopPropagation :


### PR DESCRIPTION
pageX and pageY have been redefined to be double floats instead of long ints. See: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/pageX