### PR TITLE
Fix example in README for 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ update msg ({ position } as model) =
                 ( x, y ) =
                     position
             in
-                { model | position = ( x + dx, y + dy ) } ! []
+                ( { model | position = ( round (toFloat x + dx), round (toFloat y + dy) ) }, Cmd.none )
 
         DragMsg dragMsg ->
             Draggable.update dragConfig dragMsg model


### PR DESCRIPTION
The example code in the README didn't work for 0.19 (`!` operator removed).