### PR TITLE
Allow latest released elm-pointer-events

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,7 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
-        "mpizenberg/elm-pointer-events": "3.0.0 <= v < 4.0.0"
+        "mpizenberg/elm-pointer-events": "3.0.0 <= v < 5.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.1.0 <= v < 2.0.0"


### PR DESCRIPTION
elm-pointer-events is now on 4.0.1, and nothing breaking seems to be in the changelog. I was able to run the ./smoke_test.sh with no issues.

https://github.com/mpizenberg/elm-pointer-events/blob/master/CHANGELOG.md