### PR TITLE
Fix dead link in the docs

### DIFF
--- a/src/Draggable.elm
+++ b/src/Draggable.elm
@@ -234,7 +234,7 @@ basicConfig onDragByListener =
     Config { defaultConfig | onDragBy = Just << onDragByListener }
 
 
-{-| Custom config, including arbitrary options. See [`Events`](#Draggable-Events).
+{-| Custom config, including arbitrary options. See [`Events`](Draggable-Events).
 
     config =
         customConfig


### PR DESCRIPTION
This docs link was broken, because it was pointing to *element with id `Draggable-Events` on the current page* instead of pointing user to the `Draggable-Events` page.

You can convince yourself this fix works by going to https://package.elm-lang.org/packages/zaboco/elm-draggable/latest/Draggable, ctrl + f for "See Events" and click that link (will take you nowhere). If instead you edit the link address in browser developer tool like this PR (i.e. remove `#`) it will take you to the correct page.