### PR TITLE
WIP: Allow handling all mouse button presses

### DIFF
--- a/src/Basics/Extra.elm
+++ b/src/Basics/Extra.elm
@@ -1,0 +1,7 @@
+module Basics.Extra exposing
+    ( compose2
+    )
+
+-- Allows post-composing functions to two parameter functions
+compose2 : (c -> d) -> (a -> b -> c) -> (a -> b -> d)
+compose2 = (<<) << (<<)

--- a/src/Draggable/Events.elm
+++ b/src/Draggable/Events.elm
@@ -10,6 +10,7 @@ module Draggable.Events exposing
 
 -}
 
+import Basics.Extra exposing (compose2)
 import Draggable exposing (Event)
 import Internal exposing (Config, Delta)
 
@@ -42,13 +43,13 @@ onDragBy toMsg config =
 
 {-| Register a `Click` event listener. It will trigger if the mouse is pressed and immediately release, without any move. It receives the element key.
 -}
-onClick : (a -> msg) -> Event a msg
+onClick : (a -> Int -> msg) -> Event a msg
 onClick toMsg config =
-    { config | onClick = Just << toMsg }
+    { config | onClick = compose2 Just toMsg }
 
 
 {-| Register a `MouseDown` event listener. It will trigger whenever the mouse is pressed and will indicate the target element by the given key.
 -}
-onMouseDown : (a -> msg) -> Event a msg
+onMouseDown : (a -> Int -> msg) -> Event a msg
 onMouseDown toMsg config =
-    { config | onMouseDown = Just << toMsg }
+    { config | onMouseDown = compose2 Just toMsg }


### PR DESCRIPTION
Resolves #51 

Things to still handle before possible merge:

 - Touch is currently has "button" 0 which doesn't exactly make sense
   - Could be used for the number of fingers, but dunno if that makes sense
 - This is a breaking change for both `onClick` and `onMouseDown`
   - Not sure if the API is that good either: It was the easiest way to make my use case work
   - I only really need `onMouseDown`
 - `onClick` doesn't quite work
   - Holding middle mouse button, moving mouse slightly, but still releasing top of the element doesn't trigger it
 -  Fix tests